### PR TITLE
change default password from none to 'password'

### DIFF
--- a/payload/patch_toon.sh
+++ b/payload/patch_toon.sh
@@ -7,7 +7,7 @@ echo ">>> Enabling root user"
 if [[ ! -f /etc/passwd.preroot ]]; then
   cp /etc/passwd /etc/passwd.preroot
 fi
-sed -i -e 's/^root:DISABLED:/root::/' /etc/passwd
+sed -i -e 's/^root:DISABLED:/root:uAMdksdtrttj2:/' /etc/passwd
 
 echo ">>> Opening ports 22, 80 and 10080 on firewall"
 if [[ ! -f /etc/default/iptables.conf.preroot ]]; then

--- a/payload/patch_toon.sh
+++ b/payload/patch_toon.sh
@@ -3,11 +3,14 @@ set -e
 
 cd `dirname "$0"`
 
-echo ">>> Enabling root user"
+PASS=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 10`
+PASSENC=`/usr/bin/openssl passwd -crypt $PASS 2>/dev/null`
+
+echo ">>> Enabling root user. Your generated root password is: $PASS"
 if [[ ! -f /etc/passwd.preroot ]]; then
   cp /etc/passwd /etc/passwd.preroot
 fi
-sed -i -e 's/^root:DISABLED:/root:uAMdksdtrttj2:/' /etc/passwd
+sed -i -e "s/^root:DISABLED:/root:$PASSENC:/" /etc/passwd
 
 echo ">>> Opening ports 22, 80 and 10080 on firewall"
 if [[ ! -f /etc/default/iptables.conf.preroot ]]; then


### PR DESCRIPTION
This DES encrypted root password is 'password' so in the event of problems with SSH keys the user can fallback to using this password.