### PR TITLE
Fix issue with random password

### DIFF
--- a/payload/patch_toon.sh
+++ b/payload/patch_toon.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
 set -e
 
+if [ $# -eq 0 ]; then
+  PASS=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 10`
+else
+  PASS="$1"
+fi
+
 cd `dirname "$0"`
 
-PASS=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 10`
 PASSENC=`/usr/bin/openssl passwd -crypt $PASS 2>/dev/null`
 
-echo ">>> Enabling root user. Your generated root password is: $PASS"
+echo ">>> Enabling root user. Your root password is: $PASS"
 if [[ ! -f /etc/passwd.preroot ]]; then
   cp /etc/passwd /etc/passwd.preroot
 fi

--- a/rooter.py
+++ b/rooter.py
@@ -146,7 +146,7 @@ def write_payload(port, ssh_key):
 def patch_toon(port, clean_up, reboot):
     log.info("Patching Toon")
     log.debug(port.read_until("/ # "))
-    password = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(N))
+    password = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
     port.write("sh payload/patch_toon.sh \"{}\"\n".format(password))
     try:
         while True:

--- a/rooter.py
+++ b/rooter.py
@@ -6,6 +6,8 @@ import os
 import subprocess
 import tarfile
 import base64
+import string
+import random
 from time import sleep
 from serial.serialutil import Timeout
 import StringIO
@@ -144,7 +146,8 @@ def write_payload(port, ssh_key):
 def patch_toon(port, clean_up, reboot):
     log.info("Patching Toon")
     log.debug(port.read_until("/ # "))
-    port.write("sh payload/patch_toon.sh\n")
+    password = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(N))
+    port.write("sh payload/patch_toon.sh \"{}\"\n".format(password))
     try:
         while True:
             line = read_until(port, ["/ # ", "\n"])


### PR DESCRIPTION
The environment of the first serial login is different from the final environment when you log in using SSH. It was assumed we'd have /dev/urandom during serial login but this seems not to be the case. We now generate a password in Python and push it to the script on the Toon.